### PR TITLE
messages_auto_updata

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,7 @@
 $(function(){
-  
     function buildHTML(message){
     if (message.image) {
-      var html =  `<div class="message">
+      var html =  `<div class="message" data-message-id =  ${ message.id }>
                     <div class="message__info">
                     <p class="message__info__user">
                       ${ message.user_name }
@@ -18,7 +17,7 @@ $(function(){
                   </div>`
       return html;
     } else {
-      var html = `<div class="message">
+      var html = `<div class="message"  data-message-id =  ${ message.id }>
                     <div class="message__info">
                     <p class="message__info__user">
                      ${ message.user_name }
@@ -33,6 +32,29 @@ $(function(){
                   </div>`
       return html;
     };
+  }
+
+  var reloadMessages = function() {
+    var last_message_id = $('.message:last').data('message-id');
+    $.ajax ({
+      url: 'api/messages',
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0 ) {  
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.main-chat__message-list').append(insertHTML);
+        $('.main-chat__message-list').animate({ scrollTop: $('.main-chat__message-list')[0].scrollHeight});
+       }
+    })
+    .fail(function(messages) {
+      alert("error");
+    })
   }
 
   $('#new_message').on('submit', function(e){
@@ -58,4 +80,7 @@ $(function(){
       alert("メッセージの送信に失敗しました");
     })
   });
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -61,7 +61,6 @@ $(function(){
   });
 
   $(document).on('click', '.chat-group-user__btn--add' , function(){
-    console.log
     const userName = $(this).attr('data-user-name');
     const userId = $(this).attr('data-user-id');
     $(this)

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.text message.body
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{ data: { message: { id: message.id} } }
   .message__info
     %p.message__info__user
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.text @message.body
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json'}
+    end
   end
 end


### PR DESCRIPTION
# WHY
chat-space message自動更新機能の実装

# WHAT
メッセージidをカスタムデータで設定
jqueryで取得
新規メッセージ確認用のAPIをnamespaceを使用して作成
json、jbuilserでレスポンスのためのデータを作成
message.js ファイルでレスポンスデータを表示
setIntervalを使用し、自動更新の感覚をカリキュラム通りに7000で設定。
その際に、message画面でのみ自動更新を行うよう、正規表現を使用。

# Gyazo（Gif動画：自動更新）
＜テキスト＞
https://gyazo.com/5bdb2476160193f40d59587886164e57
＜画像＞
https://gyazo.com/6c1eb8fa01275b9b2de74cbfdabea799
